### PR TITLE
Fall back to cached session on currentUser() request failure

### DIFF
--- a/lib/features/auth/data/repositories/auth_repository_impl.dart
+++ b/lib/features/auth/data/repositories/auth_repository_impl.dart
@@ -5,6 +5,7 @@ import '../../domain/entities/user_profile.dart';
 import '../../../../core/error/failures.dart';
 import '../../../../core/error/network_exceptions.dart';
 import '../datasource/auth_remote_data_source.dart';
+import '../model/user_model.dart';
 import '../../domain/repository/auth_repository.dart';
 import '../../domain/user_role.dart';
 
@@ -23,6 +24,24 @@ class AuthRepositoryImpl implements AuthRepository {
 
       return right(user);
     } on ServerException catch (e) {
+      // The real request failed (network error, timeout, etc.) - fall back
+      // to the cached local session if one exists, rather than assuming
+      // logged out. Only reached when a real request actually failed, not
+      // based on a separate connectivity probe that can false-positive
+      // (report "no internet" when the backend is actually reachable, or
+      // vice versa).
+      final session = remoteDataSource.currentUserSession;
+      if (session != null) {
+        return right(
+          UserModel(
+            id: session.user.id,
+            email: session.user.email ?? '',
+            name: '',
+            username: '',
+            role: UserRole.guest,
+          ),
+        );
+      }
       return left(Failure(e.message));
     }
   }


### PR DESCRIPTION
## Summary
Session-restore (\`currentUser()\`) treated any \`getCurrentUserData()\` failure as "not logged in" and bounced to the login screen. Now, if the request itself fails but a cached local Supabase session exists, let the user in as a degraded guest-role profile instead - the failure is a real request failure at this point, not a separate connectivity probe that can false-positive.

## Test plan
- [x] \`flutter analyze\` - clean, no new errors